### PR TITLE
Remove emptyParams

### DIFF
--- a/router.go
+++ b/router.go
@@ -98,7 +98,7 @@ func Parameters(req *http.Request) Params {
 	if p := parameterized(req); p != nil {
 		return p.params
 	}
-	return emptyParams
+	return nil
 }
 
 // Pattern gives matched route path pattern
@@ -261,7 +261,7 @@ func New(path string, handler interface{}) Router {
 
 	// maybe static route
 	if strings.IndexAny(p, ":*") == -1 {
-		ps := &parameters{params: emptyParams, pattern: p}
+		ps := &parameters{pattern: p}
 		return RouterFunc(func(req *http.Request) http.Handler {
 			if p == req.URL.Path {
 				ps.wrap(req)
@@ -369,5 +369,3 @@ func parameterized(req *http.Request) *parameters {
 	}
 	return nil
 }
-
-var emptyParams = make(Params, 0, 0)

--- a/router_test.go
+++ b/router_test.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
@@ -175,7 +174,7 @@ func TestStaticRouteMatcher(t *testing.T) {
 		}
 
 		params := Parameters(req)
-		if !reflect.DeepEqual(emptyParams, params) {
+		if len(params) > 0 {
 			t.Fatal("expected empty params")
 		}
 	}


### PR DESCRIPTION
Remove emptyParams; nil has the same properties. This is a net -2 lines
of code for router.go