### PR TITLE
Reduce the size of parameterized by two lines

### DIFF
--- a/router.go
+++ b/router.go
@@ -364,8 +364,6 @@ func (p *parameters) reset(req *http.Request) {
 }
 
 func parameterized(req *http.Request) *parameters {
-	if p, ok := req.Body.(*parameters); ok {
-		return p
-	}
-	return nil
+	p, _ := req.Body.(*parameters)
+	return p
 }


### PR DESCRIPTION
parameterized did a type assertion to see if req.Body was a *parameters,
if so, it returned the value, if not it returned nil.

Howver the two arg form of a type assertion will assign to the first
parameter a zero value of the type asserted if the type does not
match. We can use this property to avoid the branch and make the
function two lines shorter.