### PR TITLE
.travis.yml: always test with the latest point release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: go
 go:
-  - 1.3
-  - 1.4
-  - 1.5
-  - 1.6
-  - 1.7
-  - 1.8
+  - 1.3.x
+  - 1.4.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - tip   
 
 go_import_path: github.com/DATA-DOG/fastroute
 


### PR DESCRIPTION
1.8 means Go 1.8 and no other version, 1.8.x means the latest available point release in the 1.8 series, etc.